### PR TITLE
Fix preg_match() and preg_replace() null error on empty album descriptions

### DIFF
--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -11,6 +11,7 @@ function parse_lang_tag($desc)
 
 function get_user_language_desc($desc, $user_lang=null)
 {
+  $desc = isset($desc) ? $desc : '';
   global $user;
 
   if (!is_string($user_lang))


### PR DESCRIPTION
Similar to the issue resolved in https://github.com/Piwigo/ExtendedDescription/commit/f31429292e5b20ff8f2ce372de1fe63f2b42c90d, the function `get_user_language_desc` in `events.inc.php` raises deprecation warnings when calling `preg_match()` and `preg_replace()` if the description of an album is empty, as the description passed into the function is null.  This PR adds a check to `get_user_language_desc` similar to the other functions that replaces the value of `$desc` with an empty string if it is null.  This fix is tested working at https://photos.bnuuy.xyz/index.php?/category/9.